### PR TITLE
Adjusting the user block feature

### DIFF
--- a/scripts/yamblock.js
+++ b/scripts/yamblock.js
@@ -6,14 +6,14 @@ function removeBlockedUsers(userData) {
     userData.blocked.forEach(function(userId) {
         userId = userId.trim();
         $(".yj-message-list-item--avatar[data-userid=" + userId + "]").not("[style='display: none;']").each(function() {
-            traceActivity("Removing post from user:" + userId);
+            traceActivity("Removing post from user: " + userId);
 
             var index = $(this).parents().eq(2).hasClass("yj-thread-reply-list-item") ? 2 : 3;
             if (userData.blockedMethod === "0") {
                 $(this).parents().eq(index).hide();
             }
             else {
-                $(this).parents().eq(index).find(".yj-message-list-item--body-message").eq(0).text("[hidden]");
+                $(this).parents().eq(index).text("[hidden]");
             }
 
             $(this).hide();


### PR DESCRIPTION
Just replacing the message with "[hidden]" leaves attachments/images visible. Can delete $(".yj-message-list-item--attachment-container") which leaves the name and like/reply/share options, or can replace entire reply. I opted to replace the entire reply because it was a faster fix and relies less on class names that tend to change.